### PR TITLE
Don't swallow transaction exceptions

### DIFF
--- a/lib/kv.js
+++ b/lib/kv.js
@@ -294,7 +294,7 @@ KV.prototype.RunTransaction = function RunTransaction(opts, retryable, callback)
                 txnKV.Close()   
                 txnSender.txnEnd = true
 
-                callback(err, res)
+                callback(err || txnErr, res)
             })
             return
         }


### PR DESCRIPTION
Currently if the user-provided transaction function throws or aborts, the client tries to cancel it. If the cancellation succeeds, the method reports overall success. This could have been intended behavior, but it makes it impossible to tell that the transaction did not complete, so I recommend fixing it.

To fix it, I'm simply returning the transaction error if the transaction cancellation succeeded.
