### PR TITLE
Allow the URI option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,8 +6,8 @@ var proto = require('./proto.js')
 // Defaults opts
 function Options(opts) {
     this.uri = opts.uri || 'http://localhost:8080/'
-    this.host = opts.host || 'localhost'
-    this.port = opts.port || 8080
+    this.host = opts.host
+    this.port = opts.port
     this.ssl = opts.ssl ||false
     this.user = opts.user || 'root'
     this.http = opts.http || (this.ssl ? require('https') : require('http'))


### PR DESCRIPTION
The URI doesn't actually work currently, because there are defaults defined for the host and port options. (And the URI option is only used if _no_ host and port are given.)

This patch should change the behavior to what's expected. (Use host and port options if provided, otherwise use uri if provided, otherwise use default `localhost:8080`.)
