### PR TITLE
Update microtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "protobufjs": "~3.8.2"
   },
   "optionalDependencies": {
-    "microtime": "~1.1.0"
+    "microtime": "~1.4.1"
   }
 }


### PR DESCRIPTION
Fixes build error on io.js 2.x.x.
### Before:

```
> microtime@1.1.1 install /node_modules/roachjs/node_modules/microtime
> node-gyp rebuild

make: Entering directory '/node_modules/roachjs/node_modules/microtime/build'
  CXX(target) Release/obj.target/microtime/src/microtime.o
In file included from ../src/microtime.cc:11:0:
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Signature> NanNew(v8::Handle<v8::FunctionTemplate>, int, v8::Handle<v8::FunctionTemplate>*)’:
../node_modules/nan/nan.h:207:78: error: no matching function for call to ‘v8::Signature::New(v8::Isolate*, v8::Handle<v8::FunctionTemplate>&, int&, v8::Handle<v8::FunctionTemplate>*&)’
     return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
                                                                              ^
../node_modules/nan/nan.h:207:78: note: candidate is:
In file included from ../src/microtime.cc:6:0:
/home/moon/.node-gyp/2.0.1/deps/v8/include/v8.h:4188:27: note: static v8::Local<v8::Signature> v8::Signature::New(v8::Isolate*, v8::Handle<v8::FunctionTemplate>)
   static Local<Signature> New(
                           ^
/home/moon/.node-gyp/2.0.1/deps/v8/include/v8.h:4188:27: note:   candidate expects 2 arguments, 4 provided
../src/microtime.cc: In function ‘void Now(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/microtime.cc:51:72: warning: ‘v8::Local<v8::Value> node::ErrnoException(int, const char*, const char*, const char*)’ is deprecated (declared at /home/moon/.node-gyp/2.0.1/src/node.h:99): Use UVException(isolate, ...) [-Wdeprecated-declarations]
         return NanThrowError(node::ErrnoException(errno, "gettimeofday"));
                                                                        ^
../src/microtime.cc: In function ‘void NowDouble(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/microtime.cc:64:72: warning: ‘v8::Local<v8::Value> node::ErrnoException(int, const char*, const char*, const char*)’ is deprecated (declared at /home/moon/.node-gyp/2.0.1/src/node.h:99): Use UVException(isolate, ...) [-Wdeprecated-declarations]
         return NanThrowError(node::ErrnoException(errno, "gettimeofday"));
                                                                        ^
../src/microtime.cc: In function ‘void NowStruct(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/microtime.cc:77:72: warning: ‘v8::Local<v8::Value> node::ErrnoException(int, const char*, const char*, const char*)’ is deprecated (declared at /home/moon/.node-gyp/2.0.1/src/node.h:99): Use UVException(isolate, ...) [-Wdeprecated-declarations]
         return NanThrowError(node::ErrnoException(errno, "gettimeofday"));
                                                                        ^
microtime.target.mk:86: recipe for target 'Release/obj.target/microtime/src/microtime.o' failed
make: *** [Release/obj.target/microtime/src/microtime.o] Error 1
make: Leaving directory '/node_modules/roachjs/node_modules/microtime/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:169:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1009:12)
gyp ERR! System Linux 3.19.0-15-generic
gyp ERR! command "/usr/local/bin/iojs" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /node_modules/roachjs/node_modules/microtime
gyp ERR! node -v v2.0.1
gyp ERR! node-gyp -v v1.0.3
gyp ERR! not ok 
npm WARN optional dep failed, continuing microtime@1.1.1
npm WARN prefer global istanbul@0.2.5 should be installed with -g
```
### After:

```
> microtime@1.4.1 install /opt/workspace/roachjs/node_modules/microtime
> node-gyp rebuild

make: Entering directory '/opt/workspace/roachjs/node_modules/microtime/build'
  CXX(target) Release/obj.target/microtime/src/microtime.o
  SOLINK_MODULE(target) Release/obj.target/microtime.node
  SOLINK_MODULE(target) Release/obj.target/microtime.node: Finished
  COPY Release/microtime.node
make: Leaving directory '/opt/workspace/roachjs/node_modules/microtime/build'
```
