### PR TITLE
Transaction behavior fixes

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -29,15 +29,11 @@ function now(clock) {
 // read-write method. The client command ID provides idempotency
 // protection in conjunction with the server.
 Call.prototype.resetClientCmdID = function resetClientCmdID(clock) {
-    // On mutating commands, set a client command ID. This prevents
-    // mutations from being run multiple times on retries.
-    if(this.Method in proto.WriteMethods) {
-        this.Request.getHeader().set('cmd_id', new proto.ClientCmdID({
-            wall_time: now(clock),
-            // Note: 9223372036854775807 is the range of a positive int64)
-            random: Math.floor((Math.random() * 9223372036854775807) + 1)
-        }))
-    }
+    this.Request.getHeader().set('cmd_id', new proto.ClientCmdID({
+        wall_time: now(clock),
+        // Note: 9223372036854775807 is the range of a positive int64)
+        random: Math.floor((Math.random() * 9223372036854775807) + 1)
+    }))
 }
 
 // Exports

--- a/lib/client.js
+++ b/lib/client.js
@@ -52,10 +52,9 @@ Client.prototype.prepare = function PrepareClient() {
 Client.prototype.get = function Get(key, callback) {
     this.Call(proto.Get, proto.GetArgs(key), function(err, res) {
         // Extract value from res
-        if(!err && res) {
-            if(res.value.bytes) {
-                var value = res.value.bytes.buffer || null
-            }
+        var value
+        if(!err && res && res.value && res.value.bytes) {
+            value = res.value.bytes.toBuffer() || null
         }
         callback(err, value, res)
     })

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,13 +25,13 @@ function NewClient(_opts) {
     this.sender = new Sender(opts)
     this.clock  = opts.clock
 
-    return new Client(this.sender, this.clock)
+    return new Client(new KV(this.sender, this.clock))
 }
 
 // Client.js represents the exported client interface
 // This is the API for our end users
-function Client(sender, clock) {
-    this.kv = new KV(sender, clock)
+function Client(kv) {
+    this.kv = kv
     this.Call = this.kv.Call.bind(this.kv) // Default
 
     return this
@@ -43,7 +43,7 @@ function Client(sender, clock) {
 // Since the kv.Prepare api is expected to be used
 // in a sync fashion.
 Client.prototype.prepare = function PrepareClient() {
-    var client = new Client(this.kv.sender, this.kv.clock)
+    var client = new Client(this.kv)
     client.Call = client.kv.Prepare.bind(client.kv) // Upgrade
     return client
 }
@@ -129,7 +129,7 @@ Client.prototype.flush = function Flush(callback) {
 // Request to for a transactional client
 Client.prototype.runTransaction = function RunTransaction(opts, txn, callback) {
     this.kv.RunTransaction(opts, function TxnFnc(_kv, commit, abort){
-        var client = new Client(_kv.sender, _kv.clock)
+        var client = new Client(_kv)
         txn(client, commit, abort)
     }, callback)
 }

--- a/lib/cockroach_error.js
+++ b/lib/cockroach_error.js
@@ -1,0 +1,29 @@
+'use strict'
+
+var retry = require('./retry')
+var proto = require('./proto')
+
+module.exports = function CockroachError(message, header) {
+    // We're intentionally NOT capturing a stack here for two reasons:
+    // * This error occurs routinely due to database contention, so there may be
+    //   some non-negligible performance impact
+    // * This is a remote error, so the local stack trace is irrelevant anyways
+    //Error.captureStackTrace(this, this.constructor)
+    this.name = this.constructor.name
+    this.message = message
+    this.stack = this.name + ': ' + this.message +
+      '\n     remote error, no stacktrace'
+    this.header = header
+}
+
+require('util').inherits(module.exports, Error)
+
+module.exports.prototype.canRestart = function () {
+    return this.header.error.transaction_restart !== proto.ABORT
+}
+
+module.exports.prototype.getRestartPolicy = function () {
+    return this.header.error.transaction_restart === proto.BACKOFF ?
+      retry.Continue :
+      retry.Reset
+}

--- a/lib/kv.js
+++ b/lib/kv.js
@@ -121,11 +121,13 @@ KV.prototype.Prepare = function Prepare(method, request, callback) {
 
     // Validate callback
     if(callback instanceof Function) {
-        this.prepareBuffer.push(new Call({
+        var call = new Call({
             Method: method,
             Request: request,
             Callback: callback,
-        }))
+        })
+        call.resetClientCmdID(this.clock)
+        this.prepareBuffer.push(call)
     }
     // Not a valid callback
     else {

--- a/lib/kv.js
+++ b/lib/kv.js
@@ -1,8 +1,9 @@
 // Dependencies
 var TxnSender = require('./txn_sender.js')
-var Call      = require('./call.js')
-var proto     = require('./proto.js')
-var retry     = require('./retry.js')
+var Call = require('./call.js')
+var proto = require('./proto.js')
+var retry = require('./retry.js')
+var CockroachError = require('./cockroach_error')
 
 // TxnRetryOptions sets the retry options for handling write conflicts.
 var TxnRetryOptions = new retry.Options({
@@ -74,7 +75,7 @@ KV.prototype.Call = function KVCall(method, request, callback) {
         }
 
         if(!res) {
-            callback(new Error('expected an res object, received nothing'), null)
+            callback(new Error('expected a res object, received nothing'), null)
             return
         }
 
@@ -83,9 +84,8 @@ KV.prototype.Call = function KVCall(method, request, callback) {
 
         if(!header) {
             error = new Error('res object had no header, expected an header')
-        }
-        else {
-            error = header.error
+        } else if(header.error) {
+            error = new CockroachError(header.error.message, header)
         }
 
         if(error) {
@@ -246,32 +246,16 @@ KV.prototype.RunTransaction = function RunTransaction(opts, retryable, callback)
                     // TODO: i'm not sure what this err is
                     // maybe this err is only for http connections errors
                     // I'm not sure flush returns real db errors
-                    if(err instanceof proto.ReadWithinUncertaintyIntervalError) {
-                        // Retry immediately on read within uncertainty interval.
-                        retryCallback(null, retry.Reset)
-                    }
-                    else if(err instanceof proto.TransactionAbortedError) {
-                        // If the transaction was aborted, the txnSender will have created
-                        // a new txn. We allow backoff/retry in this case.
-                        retryCallback(null, retry.Continue)
-                    }
-                    else if(err instanceof proto.TransactionPushError) {
-                        // Backoff and retry on failure to push a conflicting transaction.
-                        retryCallback(null, retry.Continue)
-                    }
-                    else if(err instanceof proto.TransactionRetryError) {
-                        // Return RetryReset for an immediate retry (as in the case of
-                        // an SSI txn whose timestamp was pushed).
-                        retryCallback(null, retry.Reset)
-                    }
-                    else {
+                    if(err) {
                         // For all other cases, finish retry loop, returning possible error.
                         retryCallback(err, retry.Break)
                     }
                 })
 
                 txnKV.Flush(function(err) {
-                    if(err) {
+                    if(err instanceof CockroachError && err.canRestart()) {
+                        retryCallback(null, err.getRestartPolicy())
+                    } else {
                         // Failed to run transaction batch
                         // Abort everything...
                         retryCallback(err, retry.Break)
@@ -284,14 +268,14 @@ KV.prototype.RunTransaction = function RunTransaction(opts, retryable, callback)
                 retryCallback(null, retry.Break)
             }
         }
-        // Something when wrong, user is aborting
+        // Something went wrong, user is aborting
         var abort = function Abort(err) {
             err = err || new Error('transaction aborted by user, no error was specified.')
 
             retryCallback(err, retry.Break)
         }
 
-        // Run retryable transaction fnc
+        // Run retryable transaction function
         try {
             retryable(txnKV, commit, abort)
         } catch(e) {

--- a/lib/kv.js
+++ b/lib/kv.js
@@ -269,7 +269,7 @@ KV.prototype.RunTransaction = function RunTransaction(opts, retryable, callback)
         }
         // Something when wrong, user is aborting
         var abort = function Abort(err) {
-            err = err || new Error('transacation aborted by user, no error was specified.')
+            err = err || new Error('transaction aborted by user, no error was specified.')
 
             retryCallback(err, retry.Break)
         }

--- a/lib/kv.js
+++ b/lib/kv.js
@@ -152,9 +152,24 @@ KV.prototype.Flush = function Flush(callback) {
     }
     else if (this.prepareBuffer.length === 1) {
         var call = this.prepareBuffer[0]
-        this.Call(call.Method, call.Request, call.Callback)
+        this.Call(call.Method, call.Request, function (err, res) {
+            // This might look unncessarily complicated, but we want the
+            // behavior for single prepared calls (this logic) to match what
+            // happens for multiple prepared calls.
+            //
+            // The behavior is:
+            // * The callbacks for KV#Prepare will never receive an error and
+            //   in case of success, will receive the result value
+            // * The callback to KV#Flush will receive the error, if any, but
+            //   will not receive any result value
+            if (err) {
+                callback(err)
+                return
+            }
+            call.Callback(null, res)
+            callback(null);
+        })
         this.prepareBuffer = []
-        callback(null)
         return
     }
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -95,6 +95,12 @@ proto.TxnMethods = stringSet(
 proto.SERIALIZABLE = 0
 proto.SNAPSHOT     = 1
 
+
+// Transaction restart types
+proto.ABORT = 0
+proto.BACKOFF = 1
+proto.IMMEDIATE = 2
+
 // Helper fnc to create a get request proto
 proto.GetArgs = function GetArgs(key) {
     var header =  new proto.RequestHeader({

--- a/lib/txn_sender.js
+++ b/lib/txn_sender.js
@@ -49,14 +49,9 @@ TxnSender.prototype.Send = function Send(call, callback) {
                 for(var i in call.Request.requests) {
                     var req = call.Request.requests[i]
 
-                    // Find first non-empty, it will be the request method
-                    for(var prop in req) {
-                        if(req[prop] != null) {
-                            var method = proto.MethodForWrapper(prop)
-                            if(method === proto.EndTransaction) {
-                                self.txnEnd = true
-                            }
-                        }
+                    var method = proto.MethodForWrapper(req.value)
+                    if(method === proto.EndTransaction) {
+                        self.txnEnd = true
                     }
                 }
             }

--- a/lib/txn_sender.js
+++ b/lib/txn_sender.js
@@ -18,10 +18,35 @@ function TxnSender(wrapped, opts) {
         name: opts.name,
         isolation: opts.isolation || proto.SERIALIZABLE,
     })
+    this.deferRequest = null
 }
 
 // minimum priority.
 TxnSender.prototype.Send = function Send(call, callback) {
+    // In Go, HTTP requests are synchronous, so in the Go client all requests
+    // are naturally executed serially. In JS however, we might fire off another
+    // request while the first one is in flight.
+    //
+    // Transaction IDs are assigned by the server, so until the first request
+    // returns, we don't know the transaction ID. If we fired off another
+    // request, the server would assign another ID for the same transaction.
+    //
+    // To avoid that, we'll hold all requests until the first one returns with
+    // an ID assigned.
+    var queuedRequests
+    if (!this.txn.id) {
+        if (!this.deferRequest) {
+            // This is the very first request, set up queueing
+            queuedRequests = []
+            this.deferRequest = function (call, callback) {
+                queuedRequests.push([call, callback])
+            }
+        } else {
+            // We are waiting for the first request to return, queue this req
+            this.deferRequest(call, callback)
+            return
+        }
+    }
     call.Request.getHeader().set('txn', this.txn)
 
     var self = this
@@ -55,6 +80,17 @@ TxnSender.prototype.Send = function Send(call, callback) {
                     }
                 }
             }
+        }
+
+        if (queuedRequests) {
+            queuedRequests.forEach(function (request) {
+                try {
+                    self.Send(request[0], request[1])
+                } catch (err) {
+                    // Pass errors to the callback
+                    request[1](err)
+                }
+            })
         }
 
         callback(err, res)

--- a/lib/txn_sender.js
+++ b/lib/txn_sender.js
@@ -1,5 +1,6 @@
 // Dependencies
 var proto = require('./proto.js')
+var CockroachError = require('./cockroach_error')
 
 // A txnSender proxies requests to the underlying KVSender,
 // automatically beginning a transaction and then propagating txn
@@ -58,7 +59,7 @@ TxnSender.prototype.Send = function Send(call, callback) {
         }
 
         // Take action on various errors.
-        if(err instanceof proto.TransactionAbortedError) {
+        if(err instanceof CockroachError && err.canRestart()) {
             // On Abort, reset the transaction so we start anew on restart.
             self.txn = proto.Transaction({
                 name: self.txn.name,

--- a/lib/txn_sender_test.js
+++ b/lib/txn_sender_test.js
@@ -36,10 +36,6 @@ testSender.prototype.Send = function Sender(call, callback) {
     var header = call.Request.getHeader()
 
     header.user_priority = -1
-    if(header.txn == null && header.txn.id.length == 0) {
-        header.txn.key = txnKey
-        header.txn.id = txnID
-    }
 
     var reply;
 
@@ -80,6 +76,7 @@ exports.testTxnSenderRequestTxnTimestamp = function(test) {
         if(! compare1 == compare2) {
             test.ok(false, testIdx + ": expected ts "+compare1+" got "+ compare2)
         }
+        reply.getHeader().txn.id = txnID
         reply.getHeader().txn.timestamp = test.responseTS
         call.Callback(null, reply)
     }))


### PR DESCRIPTION
Fixes a number of issues with `TxnSender`:
- Prepared calls on transactions were dropped/ignored
- Client could erroneously submit multiple requests to assign a new transaction ID for the same transaction
